### PR TITLE
🐛 (fix): start transition from current window pos

### DIFF
--- a/lib/src/window_states.dart
+++ b/lib/src/window_states.dart
@@ -164,6 +164,18 @@ class TransitionService {
     }
   }
 
+  Future<Offset?> getCurrentWindowPosition() async {
+    if (!isDesktop) return null;
+
+    try {
+      final windowInfo = await windowManager.getBounds();
+      return Offset(windowInfo.left, windowInfo.top);
+    } catch (e) {
+      debugPrint('Error getting window position: $e');
+      return null;
+    }
+  }
+
   Future<Size> getScreenSize() async {
     if (!isDesktop) return Size.zero;
 
@@ -334,7 +346,10 @@ class _TransitionManagerState extends State<TransitionManager>
 
       final fromSize = _resolvedSizes[previousIndex];
       final toSize = _resolvedSizes[targetIndex];
-      final fromPosition = _resolvedPositions[previousIndex];
+      // Get the current window position instead of using the pre-calculated position
+      final currentPosition = await _transitionService
+          .getCurrentWindowPosition();
+      final fromPosition = currentPosition ?? _resolvedPositions[previousIndex];
       final toPosition = _resolvedPositions[targetIndex];
 
       final isExpanding =


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

When a window was manually moved by the user, subsequent transitions
would incorrectly start from the window's original configured position
instead of its current location. This created jarring animations when
switching between window states after manual repositioning.

The fix retrieves the window's current position via windowManager before
starting transitions, falling back to the pre-calculated position only
if the current position can't be determined.

This creates a much more natural user experience, with transitions
always starting from where the window actually is.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
